### PR TITLE
Update batch size

### DIFF
--- a/plant_disease.ipynb
+++ b/plant_disease.ipynb
@@ -176,7 +176,7 @@
     "validation_datagen = ImageDataGenerator(rescale=1./255)\n",
     " \n",
     "# Change the batchsize according to your system RAM\n",
-    "train_batchsize = 62\n",
+    "train_batchsize = 16\n",
     "val_batchsize = 10\n",
     " \n",
     "train_generator = train_datagen.flow_from_directory(\n",


### PR DESCRIPTION
Batch size of 62 gives core dumped.Reducing it to 16 continues to train the model.